### PR TITLE
Fixing several buffer overflow in parse_arguments in n64split

### DIFF
--- a/n64split.c
+++ b/n64split.c
@@ -2211,7 +2211,10 @@ static void parse_arguments(int argc, char *argv[], arg_config *config)
                if (++i >= argc) {
                   print_usage();
                }
-               strcpy(config->config_file, argv[i]);
+               // Unsecure 
+               // strcpy(config->config_file, argv[i]);
+               // Secure version below 
+               strncpy(config->config_file, argv[i], FILENAME_MAX);
                break;
             case 'k':
                config->keep_going = true;
@@ -2223,7 +2226,10 @@ static void parse_arguments(int argc, char *argv[], arg_config *config)
                if (++i >= argc) {
                   print_usage();
                }
-               strcpy(config->output_dir, argv[i]);
+               //Unsecure (buffer overflow)
+               // strcpy(config->output_dir, argv[i]);
+               //Secure version below without buffer overflow 
+               strncpy(config->output_dir, argv[i], FILENAME_MAX);
                break;
             case 'r':
                config->raw_texture = true;
@@ -2250,7 +2256,9 @@ static void parse_arguments(int argc, char *argv[], arg_config *config)
          }
       } else {
          if (file_count == 0) {
-            strcpy(config->input_file, argv[i]);
+            // strcpy(config->input_file, argv[i]);
+            //Secure version without buffer overflow 
+            strncpy(config->input_file, argv[i], FILENAME_MAX); 
          } else {
             // too many
             print_usage();


### PR DESCRIPTION
Hi, 

for a university project we had look for buffer overflows in open source projects. 
We have tested your software and discovered several buffer overflows in the n64split tool.

We have fixed those in this commit using `strncpy` instead of `strcpy`.

To reproduce the buffer overflow compile n64split with the gcc flag `-fno-stack-protector` and run it with the following input:
`./n64split $(python -c "print ''.join(c * 4096 for c in 'ABC') + 'D' * 72")` 

This will create a segmentation fault, because it will overwrite among others the return address of the main function. 