### PR TITLE
Add elfdump tool for disassembly of ELF object file .text sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,18 @@
 
 # Executables
 *.exe
+*.out
+/sm64compress
+/n64cksum
+/mipsdisasm
+/sm64extend
+/f3d
+/f3d2obj
+/sm64geo
+/n64graphics
+/mio0
+/n64split
+/sm64walk
+
+# Makefile dependencies
+*.d

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@
 /mio0
 /n64split
 /sm64walk
+/elfdump
 
 # Makefile dependencies
 *.d

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ GRAPHICS_TARGET := n64graphics
 MIO0_TARGET     := mio0
 SPLIT_TARGET    := n64split
 WALK_TARGET     := sm64walk
+ELFDUMP_TARGET  := elfdump
 
 LIB_SRC_FILES  := libmio0.c    \
                   libsm64.c    \
@@ -24,6 +25,10 @@ COMPRESS_SRC_FILES := sm64compress.c
 
 DISASM_SRC_FILES := mipsdisasm.c \
                     utils.c
+
+ELFDUMP_SRC_FILES := mipsdisasm.c \
+                     utils.c      \
+                     elfdump.c
 
 EXTEND_SRC_FILES := sm64extend.c
 
@@ -92,7 +97,7 @@ default: all
 
 all: $(EXTEND_TARGET) $(COMPRESS_TARGET) $(MIO0_TARGET) $(CKSUM_TARGET) \
      $(SPLIT_TARGET) $(F3D_TARGET) $(F3D2OBJ_TARGET) $(GRAPHICS_TARGET) \
-     $(DISASM_TARGET) $(GEO_TARGET) $(WALK_TARGET)
+     $(DISASM_TARGET) $(GEO_TARGET) $(WALK_TARGET) $(ELFDUMP_TARGET)
 
 $(OBJ_DIR)/%.o: %.c
 	@[ -d $(OBJ_DIR) ] || mkdir -p $(OBJ_DIR)
@@ -135,6 +140,9 @@ $(SPLIT_TARGET): $(SPLIT_OBJ_FILES)
 $(WALK_TARGET): sm64walk.c $(SM64_LIB)
 	$(CC) $(CFLAGS) -o $@ $^
 
+$(ELFDUMP_TARGET): $(ELFDUMP_SRC_FILES)
+	$(CC) $(CFLAGS) $^ $(LDFLAGS) -o $@ -lcapstone
+
 rawmips: rawmips.c utils.c
 	$(CC) $(CFLAGS) -o $@ $^ -lcapstone
 
@@ -151,6 +159,7 @@ clean:
 	rm -f $(GRAPHICS_TARGET) $(GRAPHICS_TARGET).exe
 	rm -f $(SPLIT_TARGET) $(SPLIT_TARGET).exe
 	rm -f $(WALK_TARGET) $(WALK_TARGET).exe
+	rm -f $(ELFDUMP_TARGET) $(ELFDUMP_TARGET).exe
 	-@[ -d $(OBJ_DIR) ] && rmdir --ignore-fail-on-non-empty $(OBJ_DIR)
 
 .PHONY: all clean default

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ There are many other smaller tools included to help with SM64 hacking.  They are
  - n64cksum: standalone N64 checksum generator.  can either do in place or output to a new file
  - n64graphics: converts graphics data from PNG files into RGBA or IA N64 graphics data
  - mipsdisasm: standalone recursive MIPS disassembler
+ - elfdump: disassembler for MIPS ELF object files
  - sm64geo: standalone SM64 geometry layout decoder
 
 ## License

--- a/elf.h
+++ b/elf.h
@@ -1,0 +1,61 @@
+#include <stdint.h>
+
+#define EI_DATA      5
+#define EI_NIDENT    16
+#define SHT_SYMTAB   2
+#define SHT_REL      9
+#define STN_UNDEF    0
+
+#define ELF32_R_SYM(info)  ((info) >> 8)
+#define ELF32_R_TYPE(info) ((info) & 0xff)
+
+#define R_MIPS_26    4
+#define R_MIPS_HI16  5
+#define R_MIPS_LO16  6
+
+typedef uint32_t Elf32_Addr;
+typedef uint32_t Elf32_Off;
+
+typedef struct {
+   uint8_t    e_ident[EI_NIDENT];
+   uint16_t   e_type;
+   uint16_t   e_machine;
+   uint32_t   e_version;
+   Elf32_Addr e_entry;
+   Elf32_Off  e_phoff;
+   Elf32_Off  e_shoff;
+   uint32_t   e_flags;
+   uint16_t   e_ehsize;
+   uint16_t   e_phentsize;
+   uint16_t   e_phnum;
+   uint16_t   e_shentsize;
+   uint16_t   e_shnum;
+   uint16_t   e_shstrndx;
+} Elf32_Ehdr;
+
+typedef struct {
+   uint32_t   sh_name;
+   uint32_t   sh_type;
+   uint32_t   sh_flags;
+   Elf32_Addr sh_addr;
+   Elf32_Off  sh_offset;
+   uint32_t   sh_size;
+   uint32_t   sh_link;
+   uint32_t   sh_info;
+   uint32_t   sh_addralign;
+   uint32_t   sh_entsize;
+} Elf32_Shdr;
+
+typedef struct {
+   uint32_t   st_name;
+   Elf32_Addr st_value;
+   uint32_t   st_size;
+   uint8_t    st_info;
+   uint8_t    st_other;
+   uint16_t   st_shndx;
+} Elf32_Sym;
+
+typedef struct {
+   Elf32_Addr r_offset;
+   uint32_t   r_info;
+} Elf32_Rel;

--- a/elfdump.c
+++ b/elfdump.c
@@ -1,0 +1,329 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include "mipsdisasm.h"
+#include "utils.h"
+#include "elf.h"
+
+#define ELFDUMP_VERSION "0.1"
+
+#define u32be(x) (uint32_t)(((x & 0xff) << 24) + ((x & 0xff00) << 8) + ((x & 0xff0000) >> 8) + ((uint32_t)(x) >> 24))
+#define u16be(x) (uint16_t)(((x & 0xff) << 8) + ((x & 0xff00) >> 8))
+
+typedef struct
+{
+   unsigned int start;
+   unsigned int length;
+   unsigned int vaddr;
+} range;
+
+typedef struct
+{
+   int has_vaddr;
+   unsigned int vaddr;
+   char *input_file;
+   char *output_file;
+   int merge_pseudo;
+   int emit_glabel;
+   asm_syntax syntax;
+} arg_config;
+
+static arg_config default_args =
+{
+   0,    // has_vaddr
+   0x0,  // vaddr
+   NULL, // input_file
+   NULL, // output_file
+   0,    // merge_pseudo
+   1,    // emit_glabel
+   ASM_GAS, // GNU as
+};
+
+static void print_usage(void)
+{
+   ERROR("Usage: elfdump [-g] [-o OUTPUT] [-p] [-s SYNTAX] [-v] OBJFILE [VADDR]\n"
+         "\n"
+         "elfdump v" ELFDUMP_VERSION ": MIPS ELF object file disassembler\n"
+         "\n"
+         "Optional arguments:\n"
+         " -g           emit \"glabel name\" for global labels\n"
+         " -o OUTPUT    output filename (default: stdout)\n"
+         " -p           emit pseudoinstructions for related instructions\n"
+         "              (not useful for objfiles, but possibly ELF binaries)\n"
+         " -s SYNTAX    assembler syntax to use [gas, armips] (default: gas)\n"
+         " -v           verbose progress output\n"
+         "\n"
+         "Arguments:\n"
+         " OBJFILE      ELF object file to disassemble .text section for\n"
+         " [VADDR]      virtual address of the first instruction\n");
+   exit(EXIT_FAILURE);
+}
+
+// parse command line arguments
+static void parse_arguments(int argc, char *argv[], arg_config *config)
+{
+   int has_file = 0;
+   if (argc < 2) {
+      print_usage();
+      exit(1);
+   }
+   for (int i = 1; i < argc; i++) {
+      if (argv[i][0] == '-') {
+         switch (argv[i][1]) {
+            case 'g':
+               config->emit_glabel = 1;
+               break;
+            case 'o':
+               if (++i >= argc) {
+                  print_usage();
+               }
+               config->output_file = argv[i];
+               break;
+            case 'p':
+               config->merge_pseudo = 1;
+               break;
+            case 's':
+            {
+               if (++i >= argc) {
+                  print_usage();
+               }
+               if ((0 == strcasecmp("gas", argv[i])) ||
+                   (0 == strcasecmp("gnu", argv[i]))) {
+                  config->syntax = ASM_GAS;
+               } else if (0 == strcasecmp("armips", argv[i])) {
+                  config->syntax = ASM_ARMIPS;
+               } else {
+                  print_usage();
+               }
+               break;
+            }
+            case 'v':
+               g_verbosity = 1;
+               break;
+            default:
+               print_usage();
+               break;
+         }
+      } else {
+         if (!has_file) {
+            config->input_file = argv[i];
+            has_file = 1;
+         } else if (!config->has_vaddr) {
+            config->vaddr = strtoul(argv[i], NULL, 0);
+            config->has_vaddr = 1;
+         } else {
+            print_usage();
+         }
+      }
+   }
+   if (!has_file) {
+      print_usage();
+   }
+}
+
+static void add_reloc(disasm_state *state, unsigned int offset, const char *name, int addend, unsigned int vaddr)
+{
+   char label_name[256];
+   if (!strcmp(name, ".text")) {
+      vaddr += addend;
+      addend = 0;
+      if (!disasm_label_lookup(state, vaddr, label_name)) {
+         sprintf(label_name, "static_%08X", vaddr);
+         disasm_label_add(state, label_name, vaddr);
+      }
+      name = label_name;
+   }
+
+   disasm_reloc_add(state, offset, name, addend);
+}
+
+static range parse_elf(disasm_state *state, unsigned char *data, long file_len, arg_config *args)
+{
+   Elf32_Ehdr *ehdr;
+   Elf32_Shdr *shdr, *str_shdr, *sym_shdr, *sym_strtab;
+   int text_section_index = -1;
+   int symtab_section_index = -1;
+   uint32_t text_offset = 0;
+   uint32_t vaddr_adj = 0;
+   range out_range;
+
+   if (file_len < 4 || data[0] != 0x7f || data[1] != 'E' || data[2] != 'L' || data[3] != 'F') {
+      ERROR("Not an ELF file.\n");
+      exit(EXIT_FAILURE);
+   }
+
+   ehdr = (Elf32_Ehdr *) data;
+   if (ehdr->e_ident[EI_DATA] != 2 || u16be(ehdr->e_machine) != 8) {
+      ERROR("Not big-endian MIPS.\n");
+      exit(EXIT_FAILURE);
+   }
+
+   if (u16be(ehdr->e_shstrndx) == 0) {
+      // (We could look at program headers instead in this case.)
+      ERROR("Missing section headers; stripped binaries are not yet supported.\n");
+      exit(EXIT_FAILURE);
+   }
+
+#define SECTION(index) (Elf32_Shdr *)(data + u32be(ehdr->e_shoff) + (index) * u16be(ehdr->e_shentsize))
+#define STR(strtab, offset) (const char *)(data + u32be(strtab->sh_offset) + offset)
+
+   str_shdr = SECTION(u16be(ehdr->e_shstrndx));
+   for (int i = 0; i < u16be(ehdr->e_shnum); i++) {
+      shdr = SECTION(i);
+      const char *name = STR(str_shdr, u32be(shdr->sh_name));
+      if (memcmp(name, ".text", 5) == 0) {
+         text_offset = u32be(shdr->sh_offset);
+         if (!args->has_vaddr)
+            vaddr_adj = out_range.vaddr - u32be(shdr->sh_addr);
+         else
+            out_range.vaddr = u32be(shdr->sh_addr);
+         vaddr_adj = out_range.vaddr - u32be(shdr->sh_addr);
+         out_range.length = u32be(shdr->sh_size);
+         out_range.start = text_offset;
+         text_section_index = i;
+      }
+      if (u32be(shdr->sh_type) == SHT_SYMTAB) {
+         symtab_section_index = i;
+      }
+   }
+
+   if (text_section_index == -1) {
+      ERROR("Missing .text section.\n");
+      exit(EXIT_FAILURE);
+   }
+
+   if (symtab_section_index == -1) {
+      ERROR("Missing symtab section.\n");
+      exit(EXIT_FAILURE);
+   }
+
+   // add symbols
+   sym_shdr = SECTION(symtab_section_index);
+   sym_strtab = SECTION(u32be(sym_shdr->sh_link));
+
+   assert(u32be(sym_shdr->sh_entsize) == sizeof(Elf32_Sym));
+   for (unsigned int i = 0; i < u32be(sym_shdr->sh_size); i += sizeof(Elf32_Sym)) {
+      Elf32_Sym *sym = (Elf32_Sym *)(data + u32be(sym_shdr->sh_offset) + i);
+      const char *name = STR(sym_strtab, u32be(sym->st_name));
+      uint32_t addr = u32be(sym->st_value);
+      if (u16be(sym->st_shndx) != text_section_index || name[0] == '.') {
+         continue;
+      }
+      addr += vaddr_adj;
+      disasm_label_add(state, name, addr);
+   }
+
+   // add relocations
+   for (int i = 0; i < u16be(ehdr->e_shnum); i++) {
+      Elf32_Rel *prevHi = NULL;
+      shdr = SECTION(i);
+      if (u32be(shdr->sh_type) != SHT_REL || u32be(shdr->sh_info) != (unsigned int) text_section_index)
+         continue;
+
+      assert(u32be(shdr->sh_link) == (unsigned int) symtab_section_index);
+      assert(u32be(shdr->sh_entsize) == sizeof(Elf32_Rel));
+      for (unsigned int i = 0; i < u32be(shdr->sh_size); i += sizeof(Elf32_Rel)) {
+         Elf32_Rel *rel = (Elf32_Rel *)(data + u32be(shdr->sh_offset) + i);
+         uint32_t offset = text_offset + u32be(rel->r_offset);
+         uint32_t symIndex = ELF32_R_SYM(u32be(rel->r_info));
+         uint32_t rtype = ELF32_R_TYPE(u32be(rel->r_info));
+         const char *symName = "0";
+         if (symIndex != STN_UNDEF) {
+            Elf32_Sym *sym = (Elf32_Sym *)(data + u32be(sym_shdr->sh_offset) + symIndex * sizeof(Elf32_Sym));
+            symName = STR(sym_strtab, u32be(sym->st_name));
+         }
+
+         if (rtype == R_MIPS_HI16) {
+            if (prevHi != NULL) {
+               ERROR("Consecutive R_MIPS_HI16.\n");
+               exit(EXIT_FAILURE);
+            }
+            prevHi = rel;
+            continue;
+         }
+         if (rtype == R_MIPS_LO16) {
+            int32_t addend = (int16_t)((data[offset + 2] << 8) + data[offset + 3]);
+            if (prevHi != NULL) {
+               uint32_t offset2 = text_offset + u32be(prevHi->r_offset);
+               addend += (uint32_t)((data[offset2 + 2] << 8) + data[offset2 + 3]) << 16;
+               add_reloc(state, offset2, symName, addend, out_range.vaddr);
+            }
+            prevHi = NULL;
+            add_reloc(state, offset, symName, addend, out_range.vaddr);
+         }
+         else if (rtype == R_MIPS_26) {
+            int32_t addend = (u32be(*(uint32_t*)(data + offset)) & ((1 << 26) - 1)) << 2;
+            if (addend >= (1 << 27)) {
+               addend -= 1 << 28;
+            }
+            add_reloc(state, offset, symName, addend, out_range.vaddr);
+         }
+         else {
+            ERROR("Bad relocation type %d.\n", rtype);
+            exit(EXIT_FAILURE);
+         }
+      }
+      if (prevHi != NULL) {
+         ERROR("R_MIPS_HI16 without matching R_MIPS_LO16.\n");
+         exit(EXIT_FAILURE);
+      }
+   }
+
+   return out_range;
+}
+#undef SECTION
+#undef STR
+
+int main(int argc, char *argv[])
+{
+   arg_config args;
+   long file_len;
+   disasm_state *state;
+   unsigned char *data;
+   FILE *out;
+   range r;
+
+   // load defaults and parse arguments
+   out = stdout;
+   args = default_args;
+   parse_arguments(argc, argv, &args);
+
+   // read input file
+   INFO("Reading input file '%s'\n", args.input_file);
+   file_len = read_file(args.input_file, &data);
+   if (file_len <= 0) {
+      ERROR("Error reading input file '%s'\n", args.input_file);
+      return EXIT_FAILURE;
+   }
+
+   // if specified, open output file
+   if (args.output_file != NULL) {
+      INFO("Opening output file '%s'\n", args.output_file);
+      out = fopen(args.output_file, "w");
+      if (out == NULL) {
+         ERROR("Error opening output file '%s'\n", args.output_file);
+         return EXIT_FAILURE;
+      }
+   }
+
+   state = disasm_state_init(args.syntax, args.merge_pseudo, args.emit_glabel);
+
+   r = parse_elf(state, data, file_len, &args);
+
+   // run first pass disassembler
+   INFO("Disassembling range 0x%X-0x%X at 0x%08X\n", r.start, r.start + r.length, r.vaddr);
+   mipsdisasm_pass1(data, r.start, r.length, r.vaddr, state);
+
+   // second pass, generate output
+   print_asm_header(out, args.output_file, args.syntax);
+   if (args.syntax == ASM_ARMIPS) {
+      fprintf(out, ".headersize 0x%08X\n\n", r.vaddr);
+   }
+   mipsdisasm_pass2(out, state, r.start);
+   print_asm_footer(out, args.syntax);
+
+   disasm_state_free(state);
+   free(data);
+   return EXIT_SUCCESS;
+}

--- a/mipsdisasm.c
+++ b/mipsdisasm.c
@@ -717,6 +717,9 @@ void range_parse(range *r, const char *arg)
       } else if (plus) {
          r->length = strtoul(plus+1, NULL, 0);
       }
+   } else {
+      r->start = 0;
+      r->length = 0;
    }
 }
 

--- a/mipsdisasm.c
+++ b/mipsdisasm.c
@@ -496,7 +496,7 @@ void mipsdisasm_pass2(FILE *out, disasm_state *state, unsigned int offset)
                      unsigned int branch_target = (unsigned int)insn->operands[o].imm;
                      label = labels_find(&block->locals, branch_target);
                      if (label >= 0) {
-                        fprintf(out, block->locals.labels[label].name);
+                        fprintf(out, "%s", block->locals.labels[label].name);
                      } else {
                         fprintf(out, "0x%08X", branch_target);
                      }

--- a/mipsdisasm.c
+++ b/mipsdisasm.c
@@ -399,10 +399,9 @@ void disasm_state_free(disasm_state *state)
    if (state) {
       for (int i = 0; i < state->blocks.count; i++) {
          asm_block *block = &state->blocks.items[i];
-         if (block->instructions) {
-            free(block->instructions);
-            block->instructions = NULL;
-         }
+         free(block->instructions);
+         vec_free(block->locals);
+         block->instructions = NULL;
       }
       vec_free(state->blocks);
       vec_free(state->relocs);

--- a/mipsdisasm.c
+++ b/mipsdisasm.c
@@ -9,7 +9,7 @@
 #include "mipsdisasm.h"
 #include "utils.h"
 
-#define MIPSDISASM_VERSION "0.2+"
+#define MIPSDISASM_VERSION "0.3"
 
 // typedefs
 #define vec(type) vec_ ## type

--- a/mipsdisasm.c
+++ b/mipsdisasm.c
@@ -391,14 +391,14 @@ void disasm_label_add(disasm_state *state, const char *name, unsigned int vaddr)
 
 int disasm_label_lookup(const disasm_state *state, unsigned int vaddr, char *name)
 {
-   int found = 0;
    int id = labels_find(&state->globals, vaddr);
    if (id >= 0) {
-      strcpy(name, state->globals.labels[id].name);
-      found = 1;
+      strcpy(name, state->globals.items[id].name);
+      return 1;
+   } else {
+      sprintf(name, "0x%08X", vaddr);
+      return 0;
    }
-   sprintf(name, "0x%08X", vaddr);
-   return found;
 }
 
 void mipsdisasm_pass1(unsigned char *data, unsigned int offset, unsigned int length, unsigned int vaddr, disasm_state *state)

--- a/mipsdisasm.c
+++ b/mipsdisasm.c
@@ -725,7 +725,7 @@ static void parse_arguments(int argc, char *argv[], arg_config *config)
       print_usage();
       exit(1);
    }
-   config->ranges = malloc(argc / 2 * sizeof(*config->ranges));
+   config->ranges = malloc(argc * sizeof(*config->ranges));
    config->range_count = 0;
    for (int i = 1; i < argc; i++) {
       if (argv[i][0] == '-') {

--- a/mipsdisasm.c
+++ b/mipsdisasm.c
@@ -381,11 +381,14 @@ disasm_state *disasm_state_init(asm_syntax syntax, int merge_pseudo, int emit_gl
    state->emit_glabel = emit_glabel;
 
    // open capstone disassembler
-   if (cs_open(CS_ARCH_MIPS, CS_MODE_MIPS64 + CS_MODE_BIG_ENDIAN, &state->handle) != CS_ERR_OK) {
+   if (cs_open(CS_ARCH_MIPS, CS_MODE_MIPS64 | CS_MODE_BIG_ENDIAN, &state->handle) != CS_ERR_OK) {
       ERROR("Error initializing disassembler\n");
       exit(EXIT_FAILURE);
    }
    cs_option(state->handle, CS_OPT_DETAIL, CS_OPT_ON);
+
+   // This is kinda sketchy; the capstone documentation says that cs_insn->detail
+   // is undefined when CS_OPT_SKIPDATA is set. But it's useful.
    cs_option(state->handle, CS_OPT_SKIPDATA, CS_OPT_ON);
 
    return state;

--- a/mipsdisasm.c
+++ b/mipsdisasm.c
@@ -795,7 +795,7 @@ static arg_config default_args =
 
 static void print_usage(void)
 {
-   ERROR("Usage: mipsdisasm [-g] [-o OUTPUT] [-p] [-s ASSEMBLER] [-v] ROM [RANGES]\n"
+   ERROR("Usage: mipsdisasm [-g] [-o OUTPUT] [-p] [-s SYNTAX] [-v] ROM [RANGES]\n"
          "\n"
          "mipsdisasm v" MIPSDISASM_VERSION ": MIPS disassembler\n"
          "\n"
@@ -809,7 +809,7 @@ static void print_usage(void)
          "Arguments:\n"
          " FILE         input binary file to disassemble\n"
          " [RANGES]     optional list of ranges (default: entire input file)\n"
-         "              format: <VAddr>:[<Start>-<End>] or <VAddr>:[<Start>+<Length>]\n"
+         "              format: <VAddr>[:<Start>-<End>] or <VAddr>[:<Start>+<Length>]\n"
          "              example: 0x80246000:0x1000-0x0E6258\n");
    exit(EXIT_FAILURE);
 }

--- a/mipsdisasm.c
+++ b/mipsdisasm.c
@@ -816,7 +816,7 @@ static void print_usage(void)
    exit(EXIT_FAILURE);
 }
 
-void range_parse(range *r, const char *arg)
+static void range_parse(range *r, const char *arg)
 {
    char *colon = strchr(arg, ':');
    r->vaddr = strtoul(arg, NULL, 0);

--- a/mipsdisasm.h
+++ b/mipsdisasm.h
@@ -61,7 +61,7 @@ void mipsdisasm_pass2(FILE *out, disasm_state *state, unsigned int offset);
 // get version string of raw disassembler
 const char *disasm_get_version(void);
 
-// semi-internal functions for printing beginning/end of assembly output
+// internal functions for use in mipsdisasm and elfdump
 void print_asm_header(FILE *out, const char *output_file, asm_syntax syntax);
 void print_asm_footer(FILE *out, asm_syntax syntax);
 

--- a/mipsdisasm.h
+++ b/mipsdisasm.h
@@ -30,7 +30,7 @@ void disasm_label_add(disasm_state *state, const char *name, unsigned int vaddr)
 // lookup a global label from the disassembler state
 // state: disassembler state returned from disasm_state_alloc() or mipsdisasm_pass1()
 // vaddr: virtual address of label
-// name: string to write label to
+// name: string to write label to (or vaddr if label was not found)
 // returns 1 if found, 0 otherwise
 int disasm_label_lookup(const disasm_state *state, unsigned int vaddr, char *name);
 

--- a/mipsdisasm.h
+++ b/mipsdisasm.h
@@ -13,8 +13,9 @@ typedef enum
 // allocate and initialize disassembler state to be passed into disassembler routines
 // syntax: assembler syntax to use
 // merge_pseudo: if true, attempt to link pseudo instructions
+// emit_glabel: if true, emit "glabel name" instead of "name:" for global labels
 // returns disassembler state
-disasm_state *disasm_state_init(asm_syntax syntax, int merge_pseudo);
+disasm_state *disasm_state_init(asm_syntax syntax, int merge_pseudo, int emit_glabel);
 
 // free disassembler state allocated during pass1
 // state: disassembler state returned from disasm_state_alloc() or mipsdisasm_pass1()

--- a/mipsdisasm.h
+++ b/mipsdisasm.h
@@ -52,4 +52,8 @@ void mipsdisasm_pass2(FILE *out, disasm_state *state, unsigned int offset);
 // get version string of raw disassembler
 const char *disasm_get_version(void);
 
+// semi-internal functions for printing beginning/end of assembly output
+void print_asm_header(FILE *out, const char *output_file, asm_syntax syntax);
+void print_asm_footer(FILE *out, asm_syntax syntax);
+
 #endif // MIPSDISASM_H_

--- a/mipsdisasm.h
+++ b/mipsdisasm.h
@@ -34,6 +34,15 @@ void disasm_label_add(disasm_state *state, const char *name, unsigned int vaddr)
 // returns 1 if found, 0 otherwise
 int disasm_label_lookup(const disasm_state *state, unsigned int vaddr, char *name);
 
+// Add a .text section relocation to the disassembler state, overriding merge_pseudo heuristics.
+// Whether the relocation is R_MIPS_LO16 (%lo), R_MIPS_HI16 (%hi) or R_MIPS_26 is implicit based on instruction mnemonic.
+//
+// state: disassembler state returned from disasm_state_alloc() or mipsdisasm_pass1()
+// offset: buffer offset to apply the relocation to
+// name: symbol name
+// addend: constant to add to the symbol address (typically 0)
+void disasm_reloc_add(disasm_state *state, unsigned int offset, const char *name, int addend);
+
 // first pass of disassembler - collects procedures called and sorts them
 // data: buffer containing raw MIPS assembly
 // offset: buffer offset to start at

--- a/n64split.c
+++ b/n64split.c
@@ -2355,7 +2355,7 @@ int main(int argc, char *argv[])
    }
 
    // add config labels to disasm state labels
-   state = disasm_state_init(ASM_GAS, 1);
+   state = disasm_state_init(ASM_GAS, 1, 1);
    for (i = 0; i < config.label_count; i++) {
       disasm_label_add(state, config.labels[i].name, config.labels[i].ram_addr);
    }


### PR DESCRIPTION
Plus a bunch of bugfixes, adding a flag -g for emitting `glabel`, and using that flag by default in n64split, see individual commits.

Does this seem like a reasonable addition? The main advantage compared to `mips-*-objdump -dr` is that the output is gas-compatible. (Well, almost; it currently only dumps the .text section, and with -g it doesn't output a definition for glabel. Future work.)