### PR TITLE
Fix memory allocation issue for ci textures

### DIFF
--- a/n64graphics.c
+++ b/n64graphics.c
@@ -790,11 +790,20 @@ int main(int argc, char *argv[])
    int length = 0;
    int flength;
    int res;
-
+   int w = 0;
+   int h = 0;
+   int channels = 0;
+   stbi_uc *data = stbi_load(config.img_filename, &w, &h, &channels, STBI_default);
+   
    int valid = parse_arguments(argc, argv, &config);
    if (!valid || !valid_config(&config)) {
       print_usage();
       exit(EXIT_FAILURE);
+   }
+    
+   if (!data || w <= 0 || h <= 0) {
+      ERROR("Error loading \"%s\"\n", config.img_filename);
+      return 0;
    }
 
    if (config.mode == MODE_IMPORT) {
@@ -863,7 +872,7 @@ int main(int argc, char *argv[])
                fseek(pal_fp, config.bin_offset, SEEK_SET);
             }
 
-            raw16_size = config.width * config.height * config.pal_format.depth / 8;
+            raw16_size = w * h * config.pal_format.depth / 8;
             raw16 = malloc(raw16_size);
             if (!raw16) {
                ERROR("Error allocating %d bytes\n", raw16_size);

--- a/n64graphics.c
+++ b/n64graphics.c
@@ -793,9 +793,9 @@ int main(int argc, char *argv[])
    int w = 0;
    int h = 0;
    int channels = 0;
+   int valid = parse_arguments(argc, argv, &config);
    stbi_uc *data = stbi_load(config.img_filename, &w, &h, &channels, STBI_default);
    
-   int valid = parse_arguments(argc, argv, &config);
    if (!valid || !valid_config(&config)) {
       print_usage();
       exit(EXIT_FAILURE);

--- a/n64graphics.c
+++ b/n64graphics.c
@@ -534,7 +534,7 @@ int raw2ci(uint8_t *rawci, palette_t *pal, const uint8_t *raw, int raw_len, int 
 {
    // assign colors to palette
    pal->used = 0;
-   memset(pal->data, 0, sizeof(pal->data));
+   memset16safe(pal->data, 0x07FE, sizeof(pal->data) / sizeof(uint16_t));
    int ci_idx = 0;
    for (int i = 0; i < raw_len; i += sizeof(uint16_t)) {
       uint16_t val = read_u16_be(&raw[i]);

--- a/n64graphics.c
+++ b/n64graphics.c
@@ -545,6 +545,15 @@ int raw2ci(uint8_t *rawci, palette_t *pal, const uint8_t *raw, int raw_len, int 
       } else {
          switch (ci_depth) {
             case 8:
+               // It appears some palettes have a default index of transparent/0.
+               // This requires iterating the pal_idx unless the CI really does begin with 0.
+               if (i == 0) {
+                  pal->data[0] = 0;
+                  if (val != 0) {
+                     rawci[ci_idx] = (uint8_t) ++pal_idx;
+                     break;
+                  }
+               }
                rawci[ci_idx] = (uint8_t)pal_idx;
                break;
             case 4:

--- a/n64graphics.c
+++ b/n64graphics.c
@@ -790,20 +790,11 @@ int main(int argc, char *argv[])
    int length = 0;
    int flength;
    int res;
-   int w = 0;
-   int h = 0;
-   int channels = 0;
-   int valid = parse_arguments(argc, argv, &config);
-   stbi_uc *data = stbi_load(config.img_filename, &w, &h, &channels, STBI_default);
    
+   int valid = parse_arguments(argc, argv, &config);
    if (!valid || !valid_config(&config)) {
       print_usage();
       exit(EXIT_FAILURE);
-   }
-    
-   if (!data || w <= 0 || h <= 0) {
-      ERROR("Error loading \"%s\"\n", config.img_filename);
-      return 0;
    }
 
    if (config.mode == MODE_IMPORT) {
@@ -858,6 +849,15 @@ int main(int argc, char *argv[])
             int ci_length;
             int pal_success;
             int pal_length;
+            int w = 0;
+            int h = 0;
+            int channels = 0;
+            
+            stbi_uc *data = stbi_load(config.img_filename, &w, &h, &channels, STBI_default);
+            if (!data || w <= 0 || h <= 0) {
+               ERROR("Error loading \"%s\"\n", config.img_filename);
+               return 0;
+            }
 
             if (config.pal_truncate) {
                pal_fp = fopen(config.pal_filename, "w");

--- a/utils.c
+++ b/utils.c
@@ -18,6 +18,23 @@
 // global verbosity setting
 int g_verbosity = 0;
 
+void *memset16safe(void *m, uint16_t val, size_t count)
+{
+    char *buf = m;
+    union 
+    {
+        uint8_t d8[2];
+        uint16_t d16;
+    }u16 = {.d16 = val};
+
+    while(count--) 
+    {
+        *buf++ = u16.d8[0];
+        *buf++ = u16.d8[1];
+    }
+    return m;
+}
+
 int read_s16_be(unsigned char *buf)
 {
    unsigned tmp = read_u16_be(buf);

--- a/utils.h
+++ b/utils.h
@@ -75,6 +75,9 @@ extern int g_verbosity;
 
 // functions
 
+// initialize memory to u16 value
+void *memset16safe(void *m, uint16_t val, size_t count);
+
 // convert two bytes in big-endian to signed int
 int read_s16_be(unsigned char *buf);
 


### PR DESCRIPTION
When using
```
./n64graphics -i tex.rgba.ci4.inc16.c -g tex.rgba16.ci4.png -f ci4 -s u8 -c rgba16 -p tex_gen.rgba16.ci4.inc.c -v
```
This results in a memory next error. Due to this line:
```c
raw16_size = config.width * config.height * config.pal_format.depth / 8;
```
It's still using the default of 32x32 to allocate memory. However, this texture is 128x32. Therefore, we need to read the .png's dimension metadata earlier to allocate memory based on that.

Adds `-m` argument (stands for magic number or magic filler) to specify what value to fill palettes with. This way the tail end of the palette will match.

